### PR TITLE
refactor pause action

### DIFF
--- a/tests/envs/test_graph.py
+++ b/tests/envs/test_graph.py
@@ -90,14 +90,6 @@ class TestGraph(unittest.TestCase):
         self.assertTrue(graph.is_valid_path([2, 1, 0]))
         self.assertFalse(graph.is_valid_path([0, 2]))
 
-    def test_calc_cost_with_pause_action(self):
-        graph = Graph(5)
-        graph.pause_action_cost = 5
-        self.assertEqual(graph.calculate_cost([0, 0]), 5)
-
-        graph.add_edges([[0, 0, 2]])
-        self.assertEqual(graph.calculate_cost([0, 0]), 2)
-
     def test_find_components(self):
         graph = Graph(5, directed=False)
 
@@ -167,21 +159,18 @@ class TestGraph(unittest.TestCase):
         self.assertEqual(new_graph.num_edges, 2)
 
     def test_copy(self):
-        graph = Graph(5, directed=False, pause_action_cost=5)
+        graph = Graph(5, directed=False)
         graph.add_edges([(0, 1, 10), (1, 2, 20)])
 
         graph_copy = copy.copy(graph)
-        graph_copy.pause_action_cost = 6
         graph_copy.add_edges([(2, 3, 30)])
 
         self.assertEqual(graph_copy.directed, False)
         self.assertEqual(graph_copy.num_edges, 3)
-        self.assertEqual(graph_copy.pause_action_cost, 6)
         self.assertEqual(graph_copy.edges, [[0, 1, 10], [1, 2, 20], [2, 3, 30]])
 
         self.assertEqual(graph_copy.directed, False)
         self.assertEqual(graph.num_edges, 2)
-        self.assertEqual(graph.pause_action_cost, 5)
         self.assertEqual(graph.edges, [[0, 1, 10], [1, 2, 20]])
 
     def test_init_with_numpy_edges(self):

--- a/tests/envs/test_graph.py
+++ b/tests/envs/test_graph.py
@@ -77,18 +77,22 @@ class TestGraph(unittest.TestCase):
         self.assertEqual(graph.calculate_cost([0, 1, 2]), 2 + 3)
 
     def test_is_valid_path(self):
-        graph = Graph(5, edges=[[0, 1, 2], [1, 2, 4]])
+        graph = Graph(5, edges=[[0, 1, 2], [1, 2, 4], [1, 1, 3]])
 
         self.assertTrue(graph.is_valid_path([0, 1, 2]))
         self.assertFalse(graph.is_valid_path([2, 1, 0]))
         self.assertFalse(graph.is_valid_path([0, 2]))
+        self.assertFalse(graph.is_valid_path([0, 0]))
+        self.assertTrue(graph.is_valid_path([1, 1]))
 
     def test_is_valid_path_with_undirected_graph(self):
-        graph = Graph(5, directed=False, edges=[[0, 1, 2], [1, 2, 4]])
+        graph = Graph(5, directed=False, edges=[[0, 1, 2], [1, 2, 4], [1, 1, 3]])
 
         self.assertTrue(graph.is_valid_path([0, 1, 2]))
         self.assertTrue(graph.is_valid_path([2, 1, 0]))
         self.assertFalse(graph.is_valid_path([0, 2]))
+        self.assertFalse(graph.is_valid_path([0, 0]))
+        self.assertTrue(graph.is_valid_path([1, 1]))
 
     def test_find_components(self):
         graph = Graph(5, directed=False)

--- a/tests/envs/test_grid.py
+++ b/tests/envs/test_grid.py
@@ -124,6 +124,13 @@ class TestGrid(unittest.TestCase):
         self.assertFalse(grid.is_valid_path([(0, 0), (2, 0)]))
         self.assertFalse(grid.is_valid_path([(0, 1), (1, 1), (2, 1)]))
 
+    def test_is_valid_to_pause(self):
+        grid = Grid(width=3, height=3)
+        grid.pause_weights = [[1, -1, 1], [1, 1, 1], [1, 1, 1]]
+
+        self.assertTrue(grid.is_valid_path([(0, 0), (0, 0)]))
+        self.assertFalse(grid.is_valid_path([(1, 0), (1, 0)]))
+
     def test_update_weight(self):
         grid = Grid(width=3, height=3)
         self.assertEqual(grid.get_weight((1, 1)), 1)

--- a/tests/mapf/test_space_time_a_star.py
+++ b/tests/mapf/test_space_time_a_star.py
@@ -121,3 +121,27 @@ class TestSpaceTimeAStar(unittest.TestCase):
             path,
             [(0, 0), (1, 0), (1, 1), (1, 2), (0, 2), (0, 3), (0, 4), (1, 4), (2, 4)],
         )
+
+    def test_path_with_exact_length(self):
+        """
+        + -  -  - +
+        | #     # |
+        | s     e |
+        |         |
+        + -  -  - +
+        """
+        grid = Grid(
+            weights=[[-1, 1, -1], [1, 1, 1], [1, 1, 1]],
+            pause_weights=[[1, 0.1, 1], [1, 1, 1], [1, 1, 1]],
+        )
+
+        a = SpaceTimeAStar(grid)
+        path = a.find_path_with_exact_length((0, 1), (2, 1), length=5)
+
+        # The direct path [(0,1), (1,1), (2,1)] has length 3 and cost 2.
+        # Extending it naively to length 5 by pausing at (2,1) results in:
+        #  - [(0,1), (1,1), (2,1), (2,1), (2,1)] with cost = 5.
+        # A better path uses the cheaper pause cost at (1,0), giving:
+        #  - [(0,1), (1,1), (1,0), (1,0), (1,1), (2,1)] with cost = 4.1.
+        self.assertEqual(path, [(0, 1), (1, 1), (1, 0), (1, 0), (1, 1), (2, 1)])
+        self.assertEqual(grid.calculate_cost(path), 4.1)

--- a/tests/mapf/test_space_time_a_star.py
+++ b/tests/mapf/test_space_time_a_star.py
@@ -53,13 +53,13 @@ class TestSpaceTimeAStar(unittest.TestCase):
         rt = ReservationTable(grid)
         rt.add_path(path1)
 
-        grid.pause_action_cost = 5
+        grid.pause_weights = 5
         path2 = a.find_path((0, 0), (2, 2), reservation_table=rt)
         self.assertListEqual(
             path2, [(0, 0), (1, 0), (2, 0), (2, 1), (2, 0), (2, 1), (2, 2)]
         )
 
-        grid.pause_action_cost = 0.1
+        grid.pause_weights = 0.1
         path2 = a.find_path((0, 0), (2, 2), reservation_table=rt)
         self.assertListEqual(path2, [(0, 0), (0, 0), (0, 1), (0, 2), (1, 2), (2, 2)])
 

--- a/tests/mapf/test_space_time_a_star.py
+++ b/tests/mapf/test_space_time_a_star.py
@@ -9,7 +9,7 @@ class TestSpaceTimeAStar(unittest.TestCase):
     """
 
     def test_with_directed_graph(self):
-        graph = Graph(3, edges=[[0, 1], [1, 2]])
+        graph = Graph(3, edges=[[0, 0], [0, 1], [1, 2]])
         rt = ReservationTable(graph)
         rt.add_path([1, 1, 1])
 
@@ -85,7 +85,9 @@ class TestSpaceTimeAStar(unittest.TestCase):
         a = SpaceTimeAStar(grid)
         for d in range(8):
             with self.subTest(f"search_depth={d}"):
-                path = a.find_path_with_depth_limit(start, end, search_depth=d, reservation_table=rt)
+                path = a.find_path_with_depth_limit(
+                    start, end, search_depth=d, reservation_table=rt
+                )
                 path = path[1:]  # ignore start
                 self.assertEqual(len(path), min(d, 5))
 

--- a/w9_pathfinding/bindings/cdefs.pxd
+++ b/w9_pathfinding/bindings/cdefs.pxd
@@ -15,8 +15,6 @@ cdef extern from "core.h":
         vector[vector[int]] find_components()
         vector[vector[int]] find_scc()
         bool adjacent(int, int)
-        void set_pause_action_cost(double)
-        double get_pause_action_cost()
         void set_edge_collision(bool)
         bool edge_collision()
 
@@ -29,6 +27,10 @@ cdef extern from "core.h":
         void update_weight(int, double) except +
         double get_weight(int) except +
         vector[double] get_weights()
+        void set_pause_weight(double w) except +
+        void set_pause_weights(vector[double]&) except +
+        double get_pause_weight(int) except +
+        vector[double] get_pause_weights()
 
     cdef cppclass AbsPathFinder:
         AbsPathFinder() except +

--- a/w9_pathfinding/bindings/cdefs.pxd
+++ b/w9_pathfinding/bindings/cdefs.pxd
@@ -11,7 +11,7 @@ cdef extern from "core.h":
         double calculate_cost(vector[int])
         bool is_valid_path(vector[int])
         void reverse_inplace()
-        vector[pair[int, double]] get_neighbors(int)
+        vector[pair[int, double]] get_neighbors(int, bool, bool)
         vector[vector[int]] find_components()
         vector[vector[int]] find_scc()
         bool adjacent(int, int)

--- a/w9_pathfinding/bindings/envs.pyx
+++ b/w9_pathfinding/bindings/envs.pyx
@@ -161,11 +161,11 @@ cdef class _AbsGraph:
         cdef vector[int] nodes = self._node_mapper.to_ids(path)
         return self._baseobj.is_valid_path(nodes)
 
-    def get_neighbors(self, node):
+    def get_neighbors(self, node, include_self=False):
         # return [[neighbour_id, cost], ...]
         map = self._node_mapper
         node_id = map.to_id(node)
-        neighbors = self._baseobj.get_neighbors(node_id)
+        neighbors = self._baseobj.get_neighbors(node_id, False, include_self)
         return [(map.from_id(node_id), weight) for node_id, weight in neighbors]
 
     def adjacent(self, v1, v2):

--- a/w9_pathfinding/src/core.cpp
+++ b/w9_pathfinding/src/core.cpp
@@ -5,8 +5,6 @@ double AbsGraph::calculate_cost(Path& path) {
     if (path.size() <= 1)
         return 0;
 
-    double pause_action_cost = get_pause_action_cost();
-
     double total_cost = 0;
 
     int node_id = path[0];
@@ -233,6 +231,40 @@ void AbsGrid::set_weights(vector<double> &weights) {
 
     min_weight_ = min_weight;
     weights_ = weights;
+}
+
+void AbsGrid::set_pause_weight(double w) {
+    if (w < 0)
+        throw std::invalid_argument("Pause weight must be non-negative");
+    pause_weight_ = w;
+}
+
+void AbsGrid::set_pause_weights(vector<double> &weights) {
+    if (weights.size() != size())
+        throw std::invalid_argument(
+            "Weights must have exactly " + std::to_string(size()) + " elements"
+        );
+
+    for (double w : weights) {
+        if (w < 0 && w != -1)
+            throw std::invalid_argument("Weight must be either non-negative or equal to -1");
+    }
+
+    pause_weights_ = weights;
+}
+
+double AbsGrid::get_pause_weight(int node) const {
+    if (!pause_weights_.empty())
+        return pause_weights_.at(node);
+    return pause_weight_;
+}
+
+vector<double> AbsGrid::get_pause_weights() const {
+    if (!pause_weights_.empty())
+        return pause_weights_;
+
+    vector<double> weights(size(), pause_weight_);
+    return weights;
 }
 
 vector<vector<int>> AbsGrid::find_components() {

--- a/w9_pathfinding/src/core.cpp
+++ b/w9_pathfinding/src/core.cpp
@@ -15,17 +15,11 @@ double AbsGraph::calculate_cost(Path& path) {
         int next_node_id = path[i];
 
         double step_cost = -1;
-        for (auto &[n, cost] : get_neighbors(node_id)) {
+        for (auto &[n, cost] : get_neighbors(node_id, false, true)) {
             if (n == next_node_id) {
-                if (step_cost == -1 || cost < step_cost) {
+                if (step_cost == -1 || cost < step_cost)
                     step_cost = cost;
-                }
             }
-        }
-
-        if (next_node_id == node_id) {
-            if (step_cost == -1 || pause_action_cost < step_cost)
-                step_cost = pause_action_cost;
         }
 
         if (step_cost == -1) {

--- a/w9_pathfinding/src/core.cpp
+++ b/w9_pathfinding/src/core.cpp
@@ -45,11 +45,6 @@ bool AbsGraph::is_valid_path(Path& path) {
     for (size_t i = 1; i < path.size(); i++) {
         int next_node_id = path[i];
 
-        if (next_node_id == node_id) {
-            // pause action
-            continue;
-        }
-
         if (next_node_id < 0 || next_node_id >= graph_size || !adjacent(node_id, next_node_id))
             return false;
 
@@ -180,7 +175,7 @@ vector<vector<int>> AbsGraph::find_scc() {
 }
 
 bool AbsGraph::adjacent(int v1, int v2) {
-    for (auto &[node_id, cost] : get_neighbors(v1)) {
+    for (auto &[node_id, cost] : get_neighbors(v1, false, true)) {
         if (node_id == v2) {
             return true;
         }

--- a/w9_pathfinding/src/core.cpp
+++ b/w9_pathfinding/src/core.cpp
@@ -237,6 +237,7 @@ void AbsGrid::set_pause_weight(double w) {
     if (w < 0)
         throw std::invalid_argument("Pause weight must be non-negative");
     pause_weight_ = w;
+    pause_weights_.clear();
 }
 
 void AbsGrid::set_pause_weights(vector<double> &weights) {

--- a/w9_pathfinding/src/graph.cpp
+++ b/w9_pathfinding/src/graph.cpp
@@ -71,31 +71,33 @@ vector<vector<double>> Graph::get_coordinates() const {
     return coordinates_;
 }
 
-vector<pair<int, double>> Graph::get_neighbors(int node, bool reversed) {
+vector<pair<int, double>> Graph::get_neighbors(int node, bool reversed, bool include_self) {
     vector<pair<int, double>> nb;
+
+    auto add_edges = [&] (vector<Edge> &edges) {
+        for (Edge &e : edges) {
+            if (include_self || e.node_id != node)
+                nb.push_back({e.node_id, e.cost});
+        }
+    };
 
     if (directed_) {
         if (!reversed) {
-            for (const Edge &e : edges_[node])
-                nb.push_back({e.node_id, e.cost});
+            add_edges(edges_[node]);
         }
         else {
             if (reversed_edges_.empty())
                 update_reversed_edges();
 
-            for (const Edge &e : reversed_edges_[node])
-                nb.push_back({e.node_id, e.cost});
+            add_edges(reversed_edges_[node]);
         }
     }
     else {
         if (reversed_edges_.empty())
             update_reversed_edges();
 
-        for (const Edge &e : edges_[node])
-            nb.push_back({e.node_id, e.cost});
-
-        for (const Edge &e : reversed_edges_[node])
-            nb.push_back({e.node_id, e.cost});
+        add_edges(edges_[node]);
+        add_edges(reversed_edges_[node]);
     }
 
     return nb;

--- a/w9_pathfinding/src/graph.cpp
+++ b/w9_pathfinding/src/graph.cpp
@@ -128,7 +128,6 @@ Graph* Graph::create_reversed_graph() const {
             reversed_graph->add_edge(e.node_id, i, e.cost);
         }
     }
-    reversed_graph->set_pause_action_cost(get_pause_action_cost());
     return reversed_graph;
 }
 

--- a/w9_pathfinding/src/grid.cpp
+++ b/w9_pathfinding/src/grid.cpp
@@ -115,7 +115,7 @@ vector<pair<int, double>> Grid::get_neighbors(int node, bool reversed, bool incl
 
     // add center direction
     if (include_self)
-        nb.push_back({node, get_pause_action_cost()});
+        nb.push_back({node, get_pause_weight(node)});
 
     // add cardinal directions
     int top = add_direction(0);
@@ -194,7 +194,7 @@ double Grid::calculate_cost(Path& path) {
         Point next_point = get_coordinates(path[i]);
 
         if (point == next_point) {
-            total_cost += get_pause_action_cost();
+            total_cost += get_pause_weight(path[i]);
             continue;
         }
 

--- a/w9_pathfinding/src/grid.cpp
+++ b/w9_pathfinding/src/grid.cpp
@@ -114,8 +114,11 @@ vector<pair<int, double>> Grid::get_neighbors(int node, bool reversed, bool incl
     };
 
     // add center direction
-    if (include_self)
-        nb.push_back({node, get_pause_weight(node)});
+    if (include_self) {
+        double weight = get_pause_weight(node);
+        if (weight != -1)
+            nb.push_back({node, weight});
+    }
 
     // add cardinal directions
     int top = add_direction(0);

--- a/w9_pathfinding/src/grid_3d.cpp
+++ b/w9_pathfinding/src/grid_3d.cpp
@@ -63,12 +63,15 @@ const std::array<Grid3D::Point, 6> Grid3D::directions_ = {{
     {0, 0, -1}, {0, 0, 1}, {0, -1, 0}, {0, 1, 0}, {-1, 0, 0}, {1, 0, 0}
 }};
 
-vector<pair<int, double>> Grid3D::get_neighbors(int node, bool reversed) {
+vector<pair<int, double>> Grid3D::get_neighbors(int node, bool reversed, bool include_self) {
     vector<pair<int, double>> nb;
 
     double node_weight = weights_.at(node);
     if (node_weight == -1)
         return nb;
+
+    if (include_self)
+        nb.push_back({node, get_pause_action_cost()});
 
     Point p0 = get_coordinates(node);
 

--- a/w9_pathfinding/src/grid_3d.cpp
+++ b/w9_pathfinding/src/grid_3d.cpp
@@ -71,7 +71,7 @@ vector<pair<int, double>> Grid3D::get_neighbors(int node, bool reversed, bool in
         return nb;
 
     if (include_self)
-        nb.push_back({node, get_pause_action_cost()});
+        nb.push_back({node, get_pause_weight(node)});
 
     Point p0 = get_coordinates(node);
 
@@ -136,7 +136,7 @@ double Grid3D::calculate_cost(Path& path) {
         Point next_point = get_coordinates(path[i]);
 
         if (point == next_point)
-            total_cost += get_pause_action_cost();
+            total_cost += get_pause_weight(path[i]);
         else {
             total_cost += weights_.at(path[i]);
             point = next_point;

--- a/w9_pathfinding/src/grid_3d.cpp
+++ b/w9_pathfinding/src/grid_3d.cpp
@@ -70,8 +70,11 @@ vector<pair<int, double>> Grid3D::get_neighbors(int node, bool reversed, bool in
     if (node_weight == -1)
         return nb;
 
-    if (include_self)
-        nb.push_back({node, get_pause_weight(node)});
+    if (include_self) {
+        double weight = get_pause_weight(node);
+        if (weight != -1)
+            nb.push_back({node, weight});
+    }
 
     Point p0 = get_coordinates(node);
 

--- a/w9_pathfinding/src/hex_grid.cpp
+++ b/w9_pathfinding/src/hex_grid.cpp
@@ -64,7 +64,7 @@ int HexGrid::get_direction_offset(const HexGrid::Point &p) const {
         return (p.x % 2 == layout - 2) ? 18 : 12;
 }
 
-vector<pair<int, double>> HexGrid::get_neighbors(int node, bool reversed) {
+vector<pair<int, double>> HexGrid::get_neighbors(int node, bool reversed, bool include_self) {
     vector<pair<int, double>> nb;
     
     double node_weight = weights_.at(node);
@@ -73,7 +73,10 @@ vector<pair<int, double>> HexGrid::get_neighbors(int node, bool reversed) {
 
     Point p0 = get_coordinates(node);
 
-    nb.reserve(6);
+    nb.reserve(6 + include_self);
+
+    if (include_self)
+        nb.push_back({node, get_pause_action_cost()});
 
     int offset = get_direction_offset(p0);
     for (int i = 0; i < 6; i++) {

--- a/w9_pathfinding/src/hex_grid.cpp
+++ b/w9_pathfinding/src/hex_grid.cpp
@@ -76,7 +76,7 @@ vector<pair<int, double>> HexGrid::get_neighbors(int node, bool reversed, bool i
     nb.reserve(6 + include_self);
 
     if (include_self)
-        nb.push_back({node, get_pause_action_cost()});
+        nb.push_back({node, get_pause_weight(node)});
 
     int offset = get_direction_offset(p0);
     for (int i = 0; i < 6; i++) {
@@ -136,7 +136,7 @@ double HexGrid::calculate_cost(Path& path) {
         Point next_point = get_coordinates(path[i]);
 
         if (point == next_point)
-            total_cost += get_pause_action_cost();
+            total_cost += get_pause_weight(path[i]);
         else {
             total_cost += weights_.at(path[i]);
             point = next_point;

--- a/w9_pathfinding/src/hex_grid.cpp
+++ b/w9_pathfinding/src/hex_grid.cpp
@@ -75,8 +75,11 @@ vector<pair<int, double>> HexGrid::get_neighbors(int node, bool reversed, bool i
 
     nb.reserve(6 + include_self);
 
-    if (include_self)
-        nb.push_back({node, get_pause_weight(node)});
+    if (include_self) {
+        double weight = get_pause_weight(node);
+        if (weight != -1)
+            nb.push_back({node, weight});
+    }
 
     int offset = get_direction_offset(p0);
     for (int i = 0; i < 6; i++) {

--- a/w9_pathfinding/src/include/core.h
+++ b/w9_pathfinding/src/include/core.h
@@ -27,7 +27,7 @@ class AbsGraph {
         AbsGraph() {};
         virtual ~AbsGraph() {};
         virtual size_t size() const = 0;
-        virtual vector<pair<int, double>> get_neighbors(int node, bool reversed=false) = 0;
+        virtual vector<pair<int, double>> get_neighbors(int node, bool reversed=false, bool include_self=false) = 0;
         virtual bool has_coordinates() const = 0;
 
         // returns a lower bound of the distance between two vertices

--- a/w9_pathfinding/src/include/core.h
+++ b/w9_pathfinding/src/include/core.h
@@ -133,12 +133,31 @@ class AbsGrid : public AbsGraph {
 
         void update_weight(int node, double w);
         void set_weights(vector<double> &weights);
+
+        void set_pause_weight(double w);
+        void set_pause_weights(vector<double> &weights);
+        double get_pause_weight(int node) const;
+        vector<double> get_pause_weights() const;
+
+        void clear_pause_weights() {
+            pause_weights_.clear();
+            pause_weight_ = 1;
+        }
+
         vector<vector<int>> find_components() override;
 
     protected:
-        // if weight == -1 - there is an impassable obstacle, the node is unreachable
-        // if weight >= 0 - weight is the cost of entering this node
+        // weights_[i] - cost to move to node i.
+        // If weights_[i] == -1, the node i is considered an impassable obstacle and is unreachable.
         vector<double> weights_;
+
+        // Default pause cost for all nodes.
+        // Used when pause_weights_ is empty.
+        double pause_weight_ = 1;
+
+        // pause_weights_[i] - cost to pause at node i.
+        // If pause_weights_[i] == -1, pausing is not allowed at node i.
+        vector<double> pause_weights_;
 };
 
 

--- a/w9_pathfinding/src/include/core.h
+++ b/w9_pathfinding/src/include/core.h
@@ -64,24 +64,11 @@ class AbsGraph {
 
     // For multi agent path finding
     private:
-        // the cost of the pause action
-        double pause_action_cost_ = 1;
-
         // if edge_collision_ is true, two agents can not pass on the same edge
         // at the same time in two different directions
         bool edge_collision_ = false;
 
     public:
-        void set_pause_action_cost(double cost) {
-            if (cost < 0)
-                throw std::invalid_argument("Pause action cost must be non-negative");
-            pause_action_cost_ = cost;
-        }
-
-        double get_pause_action_cost() const {
-            return pause_action_cost_;
-        }
-
         virtual void set_edge_collision(bool b) {
             edge_collision_ = b;
         }

--- a/w9_pathfinding/src/include/graph.h
+++ b/w9_pathfinding/src/include/graph.h
@@ -21,7 +21,7 @@ class Graph : public AbsGraph {
         size_t num_edges() const;
         void add_edge(int start, int end, double cost);
         void add_edges(vector<int> starts, vector<int> ends, vector<double> costs);
-        vector<pair<int, double>> get_neighbors(int node, bool reversed=false);
+        vector<pair<int, double>> get_neighbors(int node, bool reversed=false, bool include_self=false);
         vector<vector<double>> get_edges() const;
         vector<vector<double>> get_coordinates() const;
         void set_coordinates(vector<vector<double>> &coordinates);

--- a/w9_pathfinding/src/include/grid.h
+++ b/w9_pathfinding/src/include/grid.h
@@ -41,7 +41,7 @@ class Grid : public AbsGrid {
         int get_diagonal_movement() const;
         void show_obstacle_map() const;
         bool is_inside(const Point &p) const;
-        vector<pair<int, double>> get_neighbors(int node, bool reversed=false);
+        vector<pair<int, double>> get_neighbors(int node, bool reversed=false, bool include_self=false);
         int get_node_id(const Point &p) const;
         Point get_coordinates(int node) const;
         double estimate_distance(int v1, int v2) const;

--- a/w9_pathfinding/src/include/grid_3d.h
+++ b/w9_pathfinding/src/include/grid_3d.h
@@ -40,7 +40,7 @@ class Grid3D : public AbsGrid {
         int get_node_id(const Point &p) const;
         Point get_coordinates(int node) const;
         bool is_inside(const Point &p) const;
-        vector<pair<int, double>> get_neighbors(int node, bool reversed=false);
+        vector<pair<int, double>> get_neighbors(int node, bool reversed=false, bool include_self=false);
         double estimate_distance(int v1, int v2) const;
         std::string node_to_string(int v) const;
         double calculate_cost(Path& path);

--- a/w9_pathfinding/src/include/hex_grid.h
+++ b/w9_pathfinding/src/include/hex_grid.h
@@ -67,7 +67,7 @@ class HexGrid : public AbsGrid {
 
         size_t size() const;
         bool is_inside(const Point &p) const;
-        vector<pair<int, double>> get_neighbors(int node, bool reversed=false);
+        vector<pair<int, double>> get_neighbors(int node, bool reversed=false, bool include_self=false);
         int get_node_id(const Point &p) const;
         Point get_coordinates(int node) const;
         double estimate_distance(int v1, int v2) const;

--- a/w9_pathfinding/src/include/multi_agent_a_star.h
+++ b/w9_pathfinding/src/include/multi_agent_a_star.h
@@ -30,9 +30,10 @@ namespace maas {
     struct Agent {
         int start, goal;
         std::unique_ptr<ResumableSearch> rrs;
+        double goal_pause_cost;
 
-        Agent(int start, int goal, std::unique_ptr<ResumableSearch> rrs)
-            : start(start), goal(goal), rrs(std::move(rrs)) {}
+        Agent(int start, int goal, std::unique_ptr<ResumableSearch> rrs, double goal_pause_cost)
+            : start(start), goal(goal), rrs(std::move(rrs)), goal_pause_cost(goal_pause_cost) {}
     };
 
     struct Node {

--- a/w9_pathfinding/src/include/space_time_a_star.h
+++ b/w9_pathfinding/src/include/space_time_a_star.h
@@ -6,7 +6,7 @@
 #include "reservation_table.h"
 
 
-class SpaceTimeAStar {
+class SpaceTimeAStar : public AbsPathFinder {
 
     struct Node {
         Node* parent;

--- a/w9_pathfinding/src/space_time_a_star.cpp
+++ b/w9_pathfinding/src/space_time_a_star.cpp
@@ -77,7 +77,6 @@ Path SpaceTimeAStar::find_path_with_depth_limit(
 
     int graph_size = graph->size();
     int max_terminal_time = start_time + search_depth;
-    double pause_action_cost = graph->get_pause_action_cost();
 
     typedef pair<double, Node*> key;
     priority_queue<key, vector<key>, std::greater<key>> openset;
@@ -136,11 +135,8 @@ Path SpaceTimeAStar::find_path_with_depth_limit(
                 nodes.at(goal + (t + 1) * graph_size).time = -1;
         }
         else {
-            if (!rt_.is_reserved(t + 1, n))
-                process_node(n, pause_action_cost, current);
-
             auto reserved_edges = rt_.get_reserved_edges(t, n);
-            for (auto &[node_id, cost] : graph->get_neighbors(n)) {
+            for (auto &[node_id, cost] : graph->get_neighbors(n, false, true)) {
                 if (!reserved_edges.count(node_id) && !rt_.is_reserved(t + 1, node_id))
                     process_node(node_id, cost, current);
             }
@@ -171,7 +167,6 @@ Path SpaceTimeAStar::find_path_with_exact_length(
     const ReservationTable& rt_ = *rt;
 
     int graph_size = graph->size();
-    double pause_action_cost = graph->get_pause_action_cost();
     int terminal_time = start_time + length;
 
     typedef pair<double, Node*> key;
@@ -216,11 +211,8 @@ Path SpaceTimeAStar::find_path_with_exact_length(
         if (nodes.count(h) && f > nodes.at(h).f)
             continue;
 
-        if (!rt_.is_reserved(time + 1, current->node_id))
-            process_node(current->node_id, pause_action_cost, current);
-
         auto reserved_edges = rt_.get_reserved_edges(time, current->node_id);
-        for (auto &[node_id, cost] : graph->get_neighbors(current->node_id)) {
+        for (auto &[node_id, cost] : graph->get_neighbors(current->node_id, false, true)) {
             if (!reserved_edges.count(node_id) && !rt_.is_reserved(time + 1, node_id))
                 process_node(node_id, cost, current);
         }
@@ -260,7 +252,6 @@ Path SpaceTimeAStar::find_path_with_length_limit(
     const ReservationTable& rt_ = *rt;
 
     int graph_size = graph->size();
-    double pause_action_cost = graph->get_pause_action_cost();
     int terminal_time = start_time + max_length;
 
     typedef pair<double, Node*> key;
@@ -305,11 +296,8 @@ Path SpaceTimeAStar::find_path_with_length_limit(
         if (nodes.count(h) && f > nodes.at(h).f)
             continue;
 
-        if (!rt_.is_reserved(time + 1, current->node_id))
-            process_node(current->node_id, pause_action_cost, current);
-
         auto reserved_edges = rt_.get_reserved_edges(time, current->node_id);
-        for (auto &[node_id, cost] : graph->get_neighbors(current->node_id)) {
+        for (auto &[node_id, cost] : graph->get_neighbors(current->node_id, false, true)) {
             if (!reserved_edges.count(node_id) && !rt_.is_reserved(time + 1, node_id))
                 process_node(node_id, cost, current);
         }

--- a/w9_pathfinding/src/space_time_a_star.cpp
+++ b/w9_pathfinding/src/space_time_a_star.cpp
@@ -154,18 +154,6 @@ Path SpaceTimeAStar::find_path_with_exact_length(
     const ReservationTable *rt,
     int start_time
 ) {
-    if (!rt || rt->empty()) {
-        Path path = find_path_with_length_limit__static(start, goal, length);
-        if (path.empty())
-            return path;
-
-        ensure_path_length(path, length);
-
-        return path;
-    }
-
-    const ReservationTable& rt_ = *rt;
-
     int graph_size = graph->size();
     int terminal_time = start_time + length;
 
@@ -211,10 +199,16 @@ Path SpaceTimeAStar::find_path_with_exact_length(
         if (nodes.count(h) && f > nodes.at(h).f)
             continue;
 
-        auto reserved_edges = rt_.get_reserved_edges(time, current->node_id);
-        for (auto &[node_id, cost] : graph->get_neighbors(current->node_id, false, true)) {
-            if (!reserved_edges.count(node_id) && !rt_.is_reserved(time + 1, node_id))
+        if (!rt) {
+            for (auto &[node_id, cost] : graph->get_neighbors(current->node_id, false, true))
                 process_node(node_id, cost, current);
+        }
+        else {
+            auto reserved_edges = rt->get_reserved_edges(time, current->node_id);
+            for (auto &[node_id, cost] : graph->get_neighbors(current->node_id, false, true)) {
+                if (!reserved_edges.count(node_id) && !rt->is_reserved(time + 1, node_id))
+                    process_node(node_id, cost, current);
+            }
         }
     }
 


### PR DESCRIPTION
Add more fine-grained control over pause action costs — for Graph via explicit self-loop edges, and for Grid via configurable pause_action_cost (global or weights).

The plan:

- [x] Remove `pause_action_cost` attribute and related methods from `AbsGraph`.
- [x] For `Graph`: no pause actions by default. To allow pausing, manually add self-loops with appropriate weights.
- [x] For `AbsGrid` (`Grid`, `Grid3D`, and `HexGrid`): add interface to set `pause_action_cost`, which can be a single double value (global cost), or a matrix for fine-grained control.
- [x] Add `include_self` option to `get_neighbors` method (default = false).
- [x] In `AbsGrid.get_neighbors`, when `include_self = true`, return the node itself with the appropriate `pause_action_cost`.
- [x] In classic pathfinding, keep `include_self = false` (no changes needed).
- [x] For MAPF or pathfinding with dynamic obstacles, set `include_self = true`, to include center actions and avoid managing them separately.
- [x] Add tests for new `Graph` behavior: no pause actions by default.
- [x] Add tests for fine-grained `pause_action_cost` control in `Grid`.
- [x] Verify that both classic pathfinding and MAPF work correctly with the changes without significant performance degradation.